### PR TITLE
Fix install pathes

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,5 +20,6 @@ set(LIBDFX_INCLUDE_DIRS
 
 file(COPY include/libdfx.h DESTINATION ${CMAKE_BINARY_DIR}/include)
 add_library(dfx ${libdfx_sources})
+set_target_properties(dfx PROPERTIES PUBLIC_HEADER "include/libdfx.h")
 target_include_directories(dfx PUBLIC ${LIBDFX_INCLUDE_DIRS})
-install(TARGETS dfx ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install(TARGETS dfx ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} PUBLIC_HEADER ${CMAKE_INSTALL_INCLUDEDIR})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,4 +21,4 @@ set(LIBDFX_INCLUDE_DIRS
 file(COPY include/libdfx.h DESTINATION ${CMAKE_BINARY_DIR}/include)
 add_library(dfx ${libdfx_sources})
 target_include_directories(dfx PUBLIC ${LIBDFX_INCLUDE_DIRS})
-install(TARGETS dfx ARCHIVE DESTINATION ${CMAKE_BINARY_DIR}/usr/lib)
+install(TARGETS dfx ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})


### PR DESCRIPTION
Hi,

This fixes a couple of install pathes for libdfx – the actual library installation directory and the installation of libdfx. This notably helps with the Debian/Ubuntu packaging.

Thanks,
Loïc Minier