### PR TITLE
Add --default-symver flag

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 include(GNUInstallDirs)
 # Specify the minimum version for CMake
-cmake_minimum_required(VERSION 2.8.9)	
+cmake_minimum_required(VERSION 2.8.9)
 # Project's name
 project(dfx)
 enable_language(C ASM)
@@ -27,6 +27,7 @@ file(COPY include/libdfx.h DESTINATION ${CMAKE_BINARY_DIR}/include)
 add_library(dfx_shared SHARED ${libdfx_sources})
 SET_TARGET_PROPERTIES(dfx_shared PROPERTIES SOVERSION ${LIBDFX_VERSION} OUTPUT_NAME "dfx")
 SET_TARGET_PROPERTIES(dfx_shared PROPERTIES CLEAN_DIRECT_OUTPUT 1)
+SET_TARGET_PROPERTIES(dfx_shared PROPERTIES LINK_FLAGS "-Wl,--default-symver")
 
 add_library(dfx_static STATIC ${libdfx_sources})
 SET_TARGET_PROPERTIES(dfx_static PROPERTIES OUTPUT_NAME "dfx")


### PR DESCRIPTION
This flag helps us to control API compatibility with older versions of the library. Once this flag is present, dpkg-gensymbols command can be used to generate symbols file for the package to have a reference for exported api functions