### PR TITLE
Ubuntu Core enablement changes

### DIFF
--- a/doc/README.txt
+++ b/doc/README.txt
@@ -511,6 +511,224 @@ Usage example:
 
 /* More code */
 
+=================================================================================
+-FPGA state info: dfx_get_fpga_state(char *buffer, size_t buf_size)
+=================================================================================
+
+/* This API populates the user-provided buffer with the current operational
+* state of the FPGA as reported by the FPGA manager sysfs interface.
+*
+* buffer:   User buffer address to receive the FPGA state string.
+* buf_size: Size of the user-provided buffer in bytes.
+*
+* Return: Number of bytes read from sysfs in case of success.
+*         or Negative value on failure.
+*/
+
+Usage example:
+#include "libdfx.h"
+
+/* More code */
+
+char buffer[256];
+ret = dfx_get_fpga_state(buffer, sizeof(buffer));
+if (ret < 0 || strcmp(buffer, "operating") != 0)
+    return -1;
+
+/* buffer now contains the FPGA state string */
+
+/* More code */
+
+=================================================================================
+-Overlay path config: dfx_set_overlay_path(const char *overlay_dir,
+const char *requested_path)
+=================================================================================
+
+/* This API writes the requested overlay path to the overlay's `path`
+* attribute in configfs.
+* This function does not check that the path stays set - use
+* dfx_get_overlay_path and dfx_get_overlay_status to check that the application
+* of an overlay was successful.
+*
+* overlay_dir:     Path to the overlay directory in configfs.
+* requested_path: Overlay path string to be written.
+*
+* Return: 0 on success or Negative value on failure.
+*/
+
+Usage example:
+#include "libdfx.h"
+
+/* More code */
+
+ret = dfx_set_overlay_path("/sys/kernel/config/device-tree/overlays/my_overlay",
+                           "/home/user/firmwares/my_overlay.dtbo");
+if (ret < 0)
+    return -1;
+
+/* More code */
+
+=================================================================================
+-FPGA firmware load: dfx_set_fpga_firmware(const char *requested_binary_name)
+=================================================================================
+
+/* This API triggers the FPGA manager to load the specified firmware
+* binary by writing its name to the FPGA manager sysfs interface.
+* This function does not check that the firmware application succeeded.
+* Use dfx_get_fpga_state to check that the fpga was successful programmed.
+*
+* requested_binary_name: Name of the firmware binary to load (not full path)
+*
+* Return: 0 on success or Negative value on failure.
+
+
+*/
+
+Usage example:
+#include "libdfx.h"
+
+/* More code */
+
+ret = dfx_set_fpga_firmware("my_bitstream.bit.bin");
+if (ret < 0)
+    return -1;
+
+/* More code */
+
+=================================================================================
+-FPGA flags config: dfx_set_fpga_flags(const int flags)
+=================================================================================
+
+/* This API sets FPGA manager flags by writing a hex-formatted flag
+* value to the FPGA manager sysfs interface.
+*
+* flags: Integer flag value to apply.
+*
+* Return: 0 on success or Negative value on failure.
+*/
+
+Usage example:
+#include "libdfx.h"
+
+/* More code */
+
+ret = dfx_set_fpga_flags(0x20);
+if (ret < 0)
+    return -1;
+
+/* More code */
+
+=================================================================================
+-FPGA key config: dfx_set_fpga_key(const char *key)
+=================================================================================
+
+/* This API writes an AES key string to the FPGA manager via the
+* sysfs interface.
+*
+* key: AES key string to be written.
+*
+* Return: 0 on success or Negative value on failure.
+*/
+
+Usage example:
+#include "libdfx.h"
+
+/* More code */
+
+ret = dfx_set_fpga_key("0123456789abcdef0123456789abcdef");
+if (ret < 0)
+    return -1;
+
+/* More code */
+
+=================================================================================
+-Overlay path info: dfx_get_overlay_path(const char *overlay_dir,
+char *buffer, size_t buf_size)
+=================================================================================
+
+/* This API populates the user-provided buffer with the currently
+* configured overlay path from configfs.
+*
+* overlay_dir: Path to the overlay directory in configfs.
+* buffer:      User buffer address.
+* buf_size:    Size of the user-provided buffer in bytes.
+*
+* Return: Number of bytes read from configfs in case of success.
+*         or Negative value on failure.
+*/
+
+Usage example:
+#include "libdfx.h"
+
+/* More code */
+
+char buffer[256];
+ret = dfx_get_overlay_path("/sys/kernel/config/device-tree/overlays/my_overlay",
+                           buffer, sizeof(buffer));
+if (ret < 0 || strcmp(buffer, "my_overlay.dtbo") != 0)
+    return -1;
+
+/* More code */
+
+=================================================================================
+-Overlay status info: dfx_get_overlay_status(const char *overlay_dir,
+char *buffer, size_t buf_size)
+=================================================================================
+
+/* This API populates the user-provided buffer with the current
+* status of the specified overlay as reported by configfs.
+*
+* overlay_dir: Path to the overlay directory in configfs.
+* buffer:      User buffer address.
+* buf_size:    Size of the user-provided buffer in bytes.
+*
+* Return: Number of bytes read from configfs in case of success.
+*         or Negative value on failure.
+*/
+
+Usage example:
+#include "libdfx.h"
+
+/* More code */
+
+char buffer[256];
+ret = dfx_get_overlay_status("/sys/kernel/config/device-tree/overlays/my_overlay",
+                             buffer, sizeof(buffer));
+if (ret < 0)
+    return -1;
+
+/* More code */
+
+=================================================================================
+-Kernel Firmware Search Path: dfx_set_firmware_search_path(const char *file_path)
+=================================================================================
+
+/* This API tells the kernel where to search for the firmware file
+* (i.e. bitstream, dtbo, driver)
+* see https://docs.kernel.org/driver-api/firmware/fw_search_path.html
+* for more information
+*
+* The parent dir of the provided file is written to
+* /sys/module/firmware_class/parameters/path so that the kernel can discover
+* the firmware within the parent directory
+*
+* @param file_path the full path to the file to be loaded
+*
+* Return:	0 on success or Negative value on failure.
+*/
+
+Usage example:
+
+#include "libdfx.h"
+
+/* More code */
+
+ret = dfx_set_firmware_search_path("/home/user/firmwares/my_firmware.bit.bin");
+if (ret < 0)
+    return -1;
+
+/* More code */
+
 ================
 Build procedure:
 ================

--- a/src/include/libdfx.h
+++ b/src/include/libdfx.h
@@ -85,4 +85,11 @@ int dfx_cfg_init_file(const char *dfx_bin_file, const char *dfx_dtbo_file,
 		      const char *dfx_driver_dtbo_file, const char *dfx_aes_key_file,
 		      const char *devpath, unsigned long flags, ...);
 int dfx_set_firmware_search_path(const char* file_path);
+int dfx_get_fpga_state(char* buffer, size_t buf_size);
+int dfx_set_overlay_path(const char *overlay_dir, const char *requested_path);
+int dfx_set_fpga_firmware(const char *requested_binary_name);
+int dfx_set_fpga_flags(int flags);
+int dfx_set_fpga_key(const char * key);
+int dfx_get_overlay_path(const char *overlay_dir, char *buffer, size_t buf_size);
+int dfx_get_overlay_status(const char *overlay_dir, char *buffer, size_t buf_size);
 #endif

--- a/src/include/libdfx.h
+++ b/src/include/libdfx.h
@@ -84,4 +84,5 @@ int dfx_get_meta_header(char *binfile, int *buffer, int buf_size);
 int dfx_cfg_init_file(const char *dfx_bin_file, const char *dfx_dtbo_file,
 		      const char *dfx_driver_dtbo_file, const char *dfx_aes_key_file,
 		      const char *devpath, unsigned long flags, ...);
+int dfx_set_firmware_search_path(const char* file_path);
 #endif

--- a/src/libdfx.c
+++ b/src/libdfx.c
@@ -333,7 +333,7 @@ int dfx_cfg_load(int package_id)
 	}
 
 	snprintf(command, sizeof(command),
-		 "/configfs/device-tree/overlays/%s_image_%d",
+		 "/sys/kernel/config/device-tree/overlays/%s_image_%lu",
 		 package_node->package_name, package_node->package_id);
 
 	len = strlen(command) + 1;
@@ -435,7 +435,7 @@ int dfx_cfg_drivers_load(int package_id)
 	}
 
 	snprintf(command, sizeof(command),
-		 "/configfs/device-tree/overlays/%s_driver_%d",
+		 "/sys/kernel/config/device-tree/overlays/%s_driver_%lu",
 		 package_node->package_name, package_node->package_id);
 	len = strlen(command) + 1;
 	str = (char *) calloc((len), sizeof(char));
@@ -900,12 +900,11 @@ static struct dfx_package_node *create_package()
 	else
 		system("mkdir -p /lib/firmware");
 
-	FD = opendir("/configfs/device-tree/overlays/");
+	FD = opendir("/sys/kernel/config/device-tree/overlays/");
 	if (FD)
 		closedir(FD);
 	else {
-		system("mkdir -p /configfs");
-		system("mount -t configfs configfs /configfs");
+		return 0;
 	}
 
 	temp_node = first_node;


### PR DESCRIPTION
In an ongoing attempt to enable fpga device functionality in Ubuntu Core, three issues have arisen in relation to the requirement for snaps to be strictly confined. In our case, we are attempting to redistribute dfx-mgr (and libdfx) as part of [FPGAd](github.com/canonical/fpgad). Once the concept of "softeners" is in place, this snap will enable downstream customers to use dfx-mgr as they expect to be able to, but with the caveat that FPGAd will be the gatekeeper for accessing the FPGA subsystems.

In these efforts, we found three challenges in the way dfx-mgr and libdfx operate:

1. both parts of this application write to a file called `state.txt`. In real operation, this file is created at `/state.txt` which is not allowed in a strictly confined snap, and no layout can be applied to files in the root directory, except as files inside known pre-defined directories. 
2. files are freely moved in and our of /lib/firmware. In a snap's environment, this directory does not exist, so accesses to it fail. Repeatedly copying is bad for performance as well.
3. the device tree overlay subsystem's files (configfs) are remounted to `/configfs`. This mount call requires strong permissions, which the store team can't/wont to grant to the fpgad snap. 

In order to tackle these three problems, I have edited dfx-mgr and libdfx with the following solutions:

1) ~~for libdfx, state.txt is now moved to ~`/etc/dfx/state.txt`~ `/run/dfx/state.txt`. I would actually prefer to remove the "system(command)" calls to mitigate the need for this file at all, but that is out of scope here.~~ C stdlib io operations are used to write into internal buffers instead of relying on state.txt, generated using system calls. Several of the functions are exported for use in dfx-mgr (and similar) to save duplication.
2) Before anything which will trigger the kernel to look for firmware, instead of copying files to `/lib/firmware`, the containing directory is written to `/sys/module/firmware_class/parameters/path` instead. This is exported for use by dfx-mgr to save duplication.
3) the calls to mount `/configfs` are removed, and all paths pointing to "/configfs/"  are replaced by `/sys/kernel/config/` 

Please see https://github.com/Xilinx/dfx-mgr/pull/12 for the dfx-mgr changes

Please do not hesitate to suggest changes or ask for clarification. 