### PR TITLE
update cmake_minimum_required to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 #***************************************************************
 
 # Specify the minimum version for CMake
-cmake_minimum_required(VERSION 2.8.9)
+cmake_minimum_required(VERSION 3.5)
 
 project(libdfx C)
 
@@ -13,7 +13,7 @@ IF(ENABLE_LIBDFX_TIME)
 add_compile_definitions(ENABLE_LIBDFX_TIME)
 endif(ENABLE_LIBDFX_TIME)
 #link_directories(${CMAKE_BINARY_DIR}/lib)
-	
+
 # Project's name
 add_subdirectory(src)
 add_subdirectory(apps)

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -5,7 +5,7 @@
 #***************************************************************
 
 # Specify the minimum version for CMake
-cmake_minimum_required(VERSION 2.8.9)	
+cmake_minimum_required(VERSION 3.5)
 # Project's name
 project(dfx_app)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,7 +7,7 @@
 include(GNUInstallDirs)
 
 # Specify the minimum version for CMake
-cmake_minimum_required(VERSION 2.8.9)
+cmake_minimum_required(VERSION 3.5)
 
 # Project's name
 project(dfx)


### PR DESCRIPTION
Having minimum required version to be set less than 3.5 causes the error below in Ubuntu Resolute builds:
```
CMake Error at CMakeLists.txt:7 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.
```
So updating from 2.8.9 to 3.5 to fix the build with modern CMake.